### PR TITLE
fixes typo on event handler

### DIFF
--- a/projections/user-defined-projections.md
+++ b/projections/user-defined-projections.md
@@ -25,8 +25,8 @@ fromStream('account-1') //selector
 			count: 0
 		}
 	},
-	myEventType: function(state, evnt){
-		s.count += 1;
+	myEventType: function(state, event){
+		state.count += 1;
 	}
 })
 .transformBy(function(state){ //transformation


### PR DESCRIPTION
The function for the `myEventType` specifies two arguments (state and event). There appears to be a typo with the variable `evnt` (should be) `event`. The functions appears to increment the `count` by one on the incoming `state` variable however the code uses the variable `s` which will causes an issue as the `s` variable is undefined.