### PR TITLE
Added Go TCP client to "Which API or SDK to use" again

### DIFF
--- a/getting-started/which-api-sdk.md
+++ b/getting-started/which-api-sdk.md
@@ -28,6 +28,7 @@ Event Store offers a low-level protocol in the form of an asynchronous TCP proto
 -   [Java 8](https://github.com/msemys/esjc)
 -   [Maven plugin](https://github.com/fuinorg/event-store-maven-plugin)
 -   [Rust](https://gitlab.com/YoEight/eventstore-rs)
+-   [Go](https://github.com/jdextraze/go-gesclient)
 
 ## HTTP
 


### PR DESCRIPTION
Added this last summer but it was lost when website changed I guess. (Ref: https://github.com/EventStore/documentation/commit/00f94554b1e0f11e09974183dd1badb33d11cb02)