### PR TITLE
Fix to scavenge API docs

### DIFF
--- a/http-api/swagger.json
+++ b/http-api/swagger.json
@@ -68,7 +68,7 @@
           {
             "name": "threads",
             "in": "query",
-            "description": "The number of threads to run the scavenge operation on (max 3).",
+            "description": "The number of threads to run the scavenge operation on (max 4).",
             "type": "integer",
             "required": false,
             "default": 1


### PR DESCRIPTION
Max threads in scavenge operation in HTTP API docs was wrong.  The max is 4.