### PR TITLE
Incorrect Method Used In Code Snippet

### DIFF
--- a/dotnet-api/reading-events.md
+++ b/dotnet-api/reading-events.md
@@ -133,7 +133,7 @@ var nextSliceStart = StreamPosition.Start;
 do
 {
     currentSlice =
-    _eventStoreConnection.ReadStreamEventsForward("myStream", nextSliceStart,
+    _eventStoreConnection.ReadStreamEventsForwardAsync("myStream", nextSliceStart,
                                                   200, false)
                                                   .Result;
 


### PR DESCRIPTION
In the code snippet on line 136, the "Read" method should have the `Async` postfix. On line 126, in the sentence explaining the code snippet, the correct method is referenced as `ReadStreamEventsForwardAsync`.

👍