### PR TITLE
Fix json example

### DIFF
--- a/code-examples/getting-started/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1164.json
+++ b/code-examples/getting-started/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1164.json
@@ -3,7 +3,7 @@
         "eventId": "b989fe21-9469-4017-8d71-9820b8dd1164",
         "eventType": "ItemAdded",
         "data": {
-            "Description": "Xbox One S 1TB (Console)",
+            "Description": "Xbox One S 1TB (Console)"
         },
         "metadata": {
             "TimeStamp": "2016-12-23T08:00:00.9225401+01:00"
@@ -13,7 +13,7 @@
         "eventId": "b989fe21-9469-4017-8d71-9820b8dd1174",
         "eventType": "ItemAdded",
         "data": {
-            "Description": "Gears of War 4",
+            "Description": "Gears of War 4"
         },
         "metadata": {
             "TimeStamp": "2016-12-23T08:05:00.9225401+01:00"


### PR DESCRIPTION
Problem: the json provided in the doc to make an example was malformed

Solution: remove the `,` char that was generating a problem