### PR TITLE
Include SkipCertificateValidation and HTTPS gossiping changes in 5.0.9

### DIFF
--- a/dotnet-api/connecting-to-a-server.md
+++ b/dotnet-api/connecting-to-a-server.md
@@ -62,19 +62,19 @@ You can set the following values using the connection string:
 
 | Name                        | Format                                        | Description                                                          |
 | --------------------------- | --------------------------------------------- | -------------------------------------------------------------------- |
-| VerboseLogging              | True/false                                    | Enables verbose logging                                              |
+| VerboseLogging              | True/False                                    | Enables verbose logging                                              |
 | MaxQueueSize                | Integer                                       | Maximum number of outstanding operations                             |
 | MaxConcurrentItems          | Integer                                       | Maximum number of concurrent async operations                        |
 | MaxRetries                  | Integer                                       | Maximum number of retry attempts                                     |
 | MaxReconnections            | Integer                                       | The maximum number of times to try reconnecting                      |
-| RequireMaster               | True/false                                    | If set the server will only process if it is master                  |
+| RequireMaster               | True/False                                    | If set the server will only process if it is master                  |
 | ReconnectionDelay           | Integer (milliseconds)                        | The delay before attempting to reconnect                             |
 | OperationTimeout            | Integer (milliseconds)                        | The time before considering an operation timed out                   |
 | OperationTimeoutCheckPeriod | Integer (milliseconds)                        | The frequency in which to check timeouts                             |
 | DefaultUserCredentials      | String in format username:password            | The default credentials for the connection                           |
-| UseSslConnection            | True/false                                    | whether to use SSL for this connection                               |
+| UseSslConnection            | True/False                                    | Whether to use SSL for this connection                               |
 | TargetHost                  | String                                        | The hostname expected on the certificate                             |
-| ValidateServer              | True/false                                    | Whether to validate the remote server                                |
+| ValidateServer              | True/False                                    | Whether to validate the remote server                                |
 | FailOnNoServerResponse      | True/False                                    | Whether to fail on no server response                                |
 | HeartbeatInterval           | Integer (milliseconds)                        | The interval at which to send the server a heartbeat                 |
 | HeartbeatTimeout            | Integer (milliseconds)                        | The amount of time to receive a heartbeat response before timing out |
@@ -82,8 +82,9 @@ You can set the following values using the connection string:
 | MaxDiscoverAttempts         | Integer                                       | The maximum number of attempts to try to discover the cluster        |
 | ExternalGossipPort          | Integer                                       | The port to try to gossip on                                         |
 | GossipTimeout               | Integer (milliseconds)                        | The amount of time before timing out a gossip response               |
-| GossipSeeds                 | Comma separated list of ip:port               | A list of seeds to try to discover from                              |
+| GossipSeeds                 | Comma separated list of ip:port. Alternatively these ip:port pairs can be prefixed with https:// or http:// to indicate whether gossiping is to be performed over HTTP or HTTPS. By default gossiping over HTTP is used.               | A list of seeds to try to discover from                              |
 | ConnectTo                   | A URI in format described above to connect to | The URI to connect to                                                |
+| SkipCertificateValidation                   | True/False | Turns off certificate validation for node discovery                                                |
 
 > [!NOTE]
 > You can also use spacing instead of camel casing in your connection string.


### PR DESCRIPTION
Fixes https://github.com/EventStore/documentation/issues/443

The following changes were introduced in the 5.0.9 TCP Client to improve
 the support for gossiping over TLS and disabling certificate validation

- Make the use of True/False casing consistent
- Expand on the use of GossipSeeds which can now be prefixed with HTTP or HTTPS.
- Include the `SkipCertificateValidation` property which can be used to disable certificate validation.