### PR TITLE
Fix section headers for three node secure cluster using LetsEncrypt

### DIFF
--- a/docs/server/kubernetes-operator/v1.0.0/operations/database-deployment.md
+++ b/docs/server/kubernetes-operator/v1.0.0/operations/database-deployment.md
@@ -377,7 +377,7 @@ Follow these steps to deploy the cluster:
 kubectl apply -f cluster.yaml
 ```
 
-## Three Node Secure Cluster (using self-signed certificates)
+## Three Node Secure Cluster (using LetsEncrypt)
 
 The following `KurrentDB` resource type defines a three node cluster with the following properties:
 - The database will be deployed in the `kurrent` namespace with the name `kurrentdb-cluster`

--- a/docs/server/kubernetes-operator/v1.1.0/operations/database-deployment.md
+++ b/docs/server/kubernetes-operator/v1.1.0/operations/database-deployment.md
@@ -442,7 +442,7 @@ Follow these steps to deploy the cluster:
 kubectl apply -f cluster.yaml
 ```
 
-## Three Node Secure Cluster (using self-signed certificates)
+## Three Node Secure Cluster (using LetsEncrypt)
 
 The following `KurrentDB` resource type defines a three node cluster with the following properties:
 - The database will be deployed in the `kurrent` namespace with the name `kurrentdb-cluster`


### PR DESCRIPTION
## Description

The section header for the three-node LetsEncrypt-secured cluster in the Kubernetes Operator documentation says "self-signed certificates" instead of LetsEncrypt.

## Page previews

None.

