### PR TITLE
Add missing user certificates samples for rust and python

### DIFF
--- a/docs/clients/grpc/authentication.md
+++ b/docs/clients/grpc/authentication.md
@@ -54,6 +54,10 @@ To authenticate, include these two parameters in your connection string or const
 Check the samples for the following clients:
 
 ::: code-tabs
+@tab Python
+@[code{client-with-user-certificates}](@grpc:user_certificates.py)
+@tab JavaScript
+@[code{client-with-user-certificates}](@grpc:user-certificates.ts)
 @tab TypeScript
 @[code{client-with-user-certificates}](@grpc:user-certificates.ts)
 @tab Java
@@ -62,6 +66,8 @@ Check the samples for the following clients:
 @[code{client-with-user-certificates}](@grpc:user-certificates/Program.cs)
 @tab Go
 @[code{client-with-user-certificates}](@grpc:/userCertificates.go)
+@tab Rust
+@[code{client-with-user-certificates}](@grpc:/user_certificates.rs)
 :::
 
 


### PR DESCRIPTION
## Description

Add missing user certificates samples for Python and Rust client

## Page previews

![{48514584-6C43-4514-BBE1-09B5E7B164D3}](https://github.com/user-attachments/assets/514bda21-7014-43a6-9c78-575a2889eefa)
