### PR TITLE
fix http-api samples to use relative version

### DIFF
--- a/docs/.vuepress/lib/samples.ts
+++ b/docs/.vuepress/lib/samples.ts
@@ -44,7 +44,7 @@ export function resolveSamplesPath(src: string, srcCat: string | undefined) {
         },
         "@httpapi": {
             "default": {
-                path: "server/v5/http-api",
+                path: "server/{version}/http-api",
             }
         },
         "@grpc": {


### PR DESCRIPTION
Don't use v5 http-api files for every code import.