### PR TITLE
k8s operator: add example of enterprise license

### DIFF
--- a/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
+++ b/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
@@ -75,8 +75,7 @@ spec:
 
 ## Enable Enterprise Features
 
-The Operator license provided during Helm installation is different than the KurrentDB license used
-to unlock the Enterprise features of KurrentDB.
+The Operator license provided during Helm installation is different from the KurrentDB license used to unlock enterprise features.
 
 You configure your KurrentDB license by creating a Secret containing the license key, and provide
 a reference to that Secret in the `.spec.licenseSecret` field.  Note that the Secret resource and

--- a/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
+++ b/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
@@ -54,7 +54,7 @@ metadata:
   namespace: kurrent
 spec:
   replicas: 1
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   resources:
     requests:
       cpu: 1000m
@@ -71,6 +71,54 @@ spec:
     loadBalancer:
       enabled: true
     fqdnTemplate: '{podName}.{domain}'
+```
+
+## Enable Enterprise Features
+
+The Operator license provided during Helm installation is different than the KurrentDB license used
+to unlock the Enterprise features of KurrentDB.
+
+You configure your KurrentDB license by creating a Secret containing the license key, and provide
+a reference to that Secret in the `.spec.licenseSecret` field.  Note that the Secret resource and
+the KurrentDB resource must be in the same namespace.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-license-secret
+  namespace: kurrent
+type: Opaque
+stringData:
+  licenseKey: 000000-111111-222222-AAAAAA-BBBBBB-CC
+---
+apiVersion: kubernetes.kurrent.io/v1
+kind: KurrentDB
+metadata:
+  name: kurrentdb-cluster
+  namespace: kurrent
+spec:
+  replicas: 1
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+  storage:
+    volumeMode: "Filesystem"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 512Mi
+  network:
+    domain: kurrent.test
+    loadBalancer:
+      enabled: true
+    fqdnTemplate: '{podName}.{domain}'
+  licenseSecret:
+    name: my-license-secret
+    key: licenseKey
 ```
 
 ## Three Node Insecure Cluster with Two Read-Only Replicas
@@ -92,7 +140,7 @@ metadata:
   namespace: kurrent
 spec:
   replicas: 3
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   resources:
     requests:
       cpu: 1000m
@@ -160,7 +208,7 @@ metadata:
   namespace: kurrent
 spec:
   replicas: 3
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   resources:
     requests:
       cpu: 1000m
@@ -240,7 +288,7 @@ metadata:
   namespace: kurrent
 spec:
   replicas: 3
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   resources:
     requests:
       cpu: 1000m
@@ -325,7 +373,7 @@ metadata:
   namespace: kurrent
 spec:
   replicas: 3
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   resources:
     requests:
       cpu: 1000m
@@ -373,7 +421,7 @@ spec:
     - mydb-2-qn.kurrent.test:2113
   readOnlyReplicas:
     replicas: 2
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   resources:
     requests:
       cpu: 1000m
@@ -423,7 +471,7 @@ metadata:
   namespace: kurrent
 spec:
   replicas: 3
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   resources:
     requests:
       cpu: 1000m
@@ -474,7 +522,7 @@ metadata:
   namespace: kurrent
 spec:
   replicas: 1
-  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.0.0
+  image: docker.kurrent.io/kurrent-latest/kurrentdb:25.1.0
   configuration:
     RunProjections: all
     StartStandardProjections: true

--- a/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
+++ b/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
@@ -77,7 +77,7 @@ spec:
 
 The Operator license provided during Helm installation is different from the KurrentDB license used to unlock enterprise features.
 
-You configure your KurrentDB license by creating a Secret containing the license key, and provide
+Configure your KurrentDB license by creating a Secret containing the license key, and provide
 a reference to that Secret in the `.spec.licenseSecret` field.  Note that the Secret resource and
 the KurrentDB resource must be in the same namespace.
 

--- a/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
+++ b/docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md
@@ -90,7 +90,7 @@ metadata:
   namespace: kurrent
 type: Opaque
 stringData:
-  licenseKey: 000000-111111-222222-AAAAAA-BBBBBB-CC
+  licenseKey: <YOUR_LICENSE_KEY>
 ---
 apiVersion: kubernetes.kurrent.io/v1
 kind: KurrentDB


### PR DESCRIPTION
### **User description**
## Description

## Page previews

<!-- Add the specific pages that your PR changes here -->


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Add enterprise license configuration example for KurrentDB

- Document how to create and reference license secrets in Kubernetes

- Update all KurrentDB image versions from 25.0.0 to 25.1.0

- Include complete YAML manifest with license secret setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Documentation Update"] --> B["Enterprise License Section"]
  B --> C["Secret Configuration Example"]
  B --> D["KurrentDB Manifest with License"]
  A --> E["Version Updates"]
  E --> F["25.0.0 to 25.1.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database-deployment.md</strong><dd><code>Add enterprise license configuration and update versions</code>&nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/v1.4.3/operations/database-deployment.md

<ul><li>Added new "Enable Enterprise Features" section with comprehensive <br>documentation<br> <li> Provided example Kubernetes Secret manifest for license key storage<br> <li> Included complete KurrentDB deployment example with <code>licenseSecret</code> <br>configuration<br> <li> Updated all KurrentDB image versions from 25.0.0 to 25.1.0 across <br>multiple examples</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/936/files#diff-e6bd35454982d9fc69b6078c5f3c29b98e1e1fcbdc88c5b2a26bbec708ec63c9">+56/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

