### PR TITLE
[DB-1792] Make rc clearer since 'preview' isn't obvious

### DIFF
--- a/import/repos.json
+++ b/import/repos.json
@@ -10,6 +10,7 @@
     "branches": [
       {
         "version": "v26.0",
+        "alias": "v26.0 RC",
         "preview": true,
         "name": "release/v26.0",
         "relativePath": ["server"],


### PR DESCRIPTION
### **User description**
## Description

## Page previews

<!-- Add the specific pages that your PR changes here -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add alias field to clarify RC version status

- Improves version labeling clarity for v26.0 release


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["repos.json config"] -- "add alias field" --> B["v26.0 RC label"]
  B -- "clarifies preview status" --> C["improved version clarity"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repos.json</strong><dd><code>Add RC alias to v26.0 version entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

import/repos.json

<ul><li>Added <code>alias</code> field with value "v26.0 RC" to the v26.0 version entry<br> <li> Clarifies that the preview version is a release candidate<br> <li> Improves user understanding of version status without relying on <br>"preview" flag alone</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/939/files#diff-670025d3a58927b815b92494aed3fda8b96fed56858c9ac747214ff690fe04ff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

