### PR TITLE
docs changes for 1.4.3 -> 1.5.0

### DIFF
--- a/docs/server/kubernetes-operator/v1.5.0/README.md
+++ b/docs/server/kubernetes-operator/v1.5.0/README.md
@@ -1,5 +1,5 @@
 ---
 # title is for breadcrumb and sidebar nav
-title: Kubernetes Operator v1.4.3
+title: Kubernetes Operator v1.5.0
 order: 1
 ---

--- a/docs/server/kubernetes-operator/v1.5.0/getting-started/README.md
+++ b/docs/server/kubernetes-operator/v1.5.0/getting-started/README.md
@@ -9,67 +9,63 @@ dir:
 <CloudBanner />
 
 ---
-Welcome to the **KurrentDB Kubernetes Operator** guide. In this guide, we’ll refer to the KurrentDB Kubernetes Operator simply as “the Operator.” Use the Operator to simplify backup, scaling, and upgrades of KurrentDB clusters on Kubernetes.
+Welcome to the **KurrentDB Kubernetes Operator** guide. In this guide, we’ll refer to the KurrentDB
+Kubernetes Operator simply as “the Operator.” Use the Operator to simplify backup, scaling, and
+upgrades of KurrentDB clusters on Kubernetes.
 
 :::important
-The Operator is an Enterprise-only feature, please [contact us](https://www.kurrent.io/contact) for more information.
+The Operator is an Enterprise-only feature, please [contact us](https://www.kurrent.io/contact) for
+more information.
 :::
 
 ## Why run KurrentDB on Kubernetes?
 
-Kubernetes is the modern enterprise standard for deploying containerized applications at scale. The Operator streamlines deployment and management of KurrentDB clusters.
+Kubernetes is the modern enterprise standard for deploying containerized applications at scale. The
+Operator streamlines deployment and management of KurrentDB clusters.
 
 ## Features
 
-* Deploy single-node or multi-node clusters
-* Back up and restore clusters
+* Deploy single-node or multi-node KurrentDB clusters, even across multiple Kubernetes clusters
+* Back up and restore KurrentDB clusters
 * Automate backups with a schedule and retention policies
+* Automatically detect and load TLS certificate updates
+* Configure KurrentDB initial users and passwords
 * Perform rolling upgrades and update configurations
 
-### New in 1.4.0
+### New in 1.5.0
 
-* Support configurable traffic strategies for each of server-server and client-server traffic.  This
-  enables the use of LetsEncrypt certificates without creating Ingresses, for example.  See
-  [Traffic Strategies][ts] for details.
-* Support backup scheduling and retention policies.  There is a new [KurrentDBBackupSchedule][bs]
-  CRD with a CronJob-like syntax.  There are also two mechanisms for configuring retention policies:
-  a `.keep` count on `KurrentDBBackupSchedule`, and a new `.ttl` on `KurrentDBBackup`.
-* Support standalone read-only replicas pointed at a remote cluster.  This enables advanced
-  topologies like a having your quorum nodes in one region and a read-only replica in a distant
-  region.  See [Deploying Standalone Read-Only Replicas][ror] for an example.
-* Support template strings in some extra metadata for child resources of the `KurrentDB` object.
-  This allows, for example, to annotate each of the automatically created LoadBalancers with unique
-  external-dns annotations.  See [KurrentDBExtraMetadataSpec][em] for details.
+* Support Archiver nodes.  Archiver nodes are a KurrentDB feature that lets you offload your old,
+  less-frequently-accessed data into blob storage.  See [an example][arx].
+* Support for running KurrentDB pods under a specific `ServiceAccount`, to support IRSA access to
+  cloud storage for archiving.  See the [serviceAccountName setting][san] setting.
+* Management of initial user configuration.  The `admin` and `ops` passwords can be set on database
+  creation, as well as fully custom users.  See [an example of a secure deployment][usr].
+* Automatically detect TLS certificate updates and load them into the database with zero downtime.
+  With cert-manager (or any automated cert renewal system), certificate rotation now requires zero
+  administrator action.
+* Support multiple custom certificate authorities.  This supports migrating from one CA to another
+  without downtime, and also supports multi-kubernetes-cluster topologies with self-signed
+  certificates without having to transfer root CA private keys between clusters. See the
+  [certificateAuthoritySecret setting][sec].
+* Support 5-node clusters.  A 5-node cluster ensures that, even during a rolling restart, you can
+  still lose one node without risk of data loss.
+* Support telemetry opt-out.  See the [telemetryOptOut setting][tlm].
+* Support loadBalancerClass configuration.  See the [loadBalancerClass setting][lbs].
+* Support for non-`cluster.local` cluster domains (automatically detected).
+* Label pods with their current role in the KurrentDB cluster.  The label is updated after every
+  successful health check, which is about once every minute.
+* Support NodePort configuration.
+* Allow administrators to explicitly request configuration reloads, rolling restarts, or full
+  restarts of a KurrentDB cluster.  See the [Manually Triggering Reload or Restarts][trg] for
+  details.
 
-[ts]: ../operations/advanced-networking.md#traffic-strategy-options
-[bs]: resource-types.md#kurrentdbbackupschedulespec
-[ror]: ../operations/database-deployment.md#deploying-standalone-read-only-replicas
-[em]: resource-types.md#kurrentdbextrametadataspec
-
-### New in 1.4.1
-
-* Fix rolling restarts to be quorum-aware for extra data safety.
-* Add quorum-aware full restarts for changes that must be applied to all nodes at once, like adding
-  TLS.
-* Fix the `internodeTrafficStrategy: SplitDNS` setting to run correctly on more container runtimes.
-* Fix a hang caused adding to pod labels in `extraMetadata` after a KurrentDB was deployed.
-* Correctly enforce the immutability of the `sourceBackup` setting to prevent confusing behavior.
-* Fix the helm chart to prevent allowing two operator instances to briefly conflict during upgrades.
-
-### New in 1.4.2
-
-* Fix bug where deleting KurrentDBs with LoadBalancers enabled could leave dangling cloud resources.
-* Automatically grow PVC requested storage size to match the `restoreSize` of a VolumeSnapshot, when
-  starting new nodes from VolumeSnapshots.  This could happen when a user had SourceBackup set or
-  when adding new quorum nodes or read-only replicas to an existing cluster.
-* Allow extra metadata for resources deployed by the Helm chart.  See `values.yaml` in the Helm
-  chart for details.
-
-### New in 1.4.3
-
-* Officially support running in RedHat OpenShift clusters.
-* Support deploying through the Operator Lifecycle Manager (OLM) in addition to Helm.  OLM is the
-  recommended mechanism for deploying operators in OpenShift.
+[arx]: ../operations/database-deployment.md#three-node-insecure-cluster-with-archiving
+[san]: resource-types.md#kurrentdbspec
+[usr]: ../operations/database-deployment.md#three-node-secure-cluster-using-self-signed-certificates
+[sec]: resource-types.md#kurrentdbsecurity
+[tlm]: resource-types.md#kurrentdbspec
+[lbs]: resource-types.md#kurrentdbloadbalancer
+[trg]: ../operations/modify-deployments.md#manually-triggering-reload-or-restart
 
 ## Supported KurrentDB Versions
 
@@ -79,7 +75,6 @@ The Operator supports running the following major versions of KurrentDB:
 - v23.10+
 
 ## Supported Hardware Architectures
-
 The Operator is packaged for the following hardware architectures:
 - x86\_64
 - arm64

--- a/docs/server/kubernetes-operator/v1.5.0/getting-started/installation.md
+++ b/docs/server/kubernetes-operator/v1.5.0/getting-started/installation.md
@@ -46,7 +46,7 @@ To install in this way, run:
 
 ```bash
 helm install kurrentdb-operator kurrent-latest/kurrentdb-operator \
-  --version 1.4.3 \
+  --version 1.5.0 \
   --create-namespace \
   --namespace kurrent-system \
   --set-file operator.license.key=/path/to/license.key \
@@ -97,7 +97,7 @@ install the CRDs before the Helm installation (and again with each upgrade):
 
 ```bash
 # Download the kurrentdb-operator Helm chart
-helm pull kurrent-latest/kurrentdb-operator --version 1.4.3 --untar
+helm pull kurrent-latest/kurrentdb-operator --version 1.5.0 --untar
 
 # Install the CRDs
 kubectl apply -f kurrentdb-operator/templates/crds
@@ -139,7 +139,7 @@ helm upgrade kurrentdb-operator kurrent-latest/kurrentdb-operator \
 Here's what these commands do:
 - Refresh the local Helm repository index
 - Locate an existing operator installation in namespace `kurrent`
-- Select the target upgrade version `{version}` e.g. `1.4.3`
+- Select the target upgrade version `{version}` e.g. `1.5.0`
 - Perform the upgrade, preserving values that were set during installation
 
 ## Install Using OLM
@@ -237,7 +237,7 @@ spec:
   name: kurrentdb-operator
   source: kurrentdb-operator
   sourceNamespace: default
-  startingCSV: kurrentdb-operator.v1.4.3
+  startingCSV: kurrentdb-operator.v1.5.0
 EOF
 ```
 

--- a/docs/server/kubernetes-operator/v1.5.0/getting-started/resource-types.md
+++ b/docs/server/kubernetes-operator/v1.5.0/getting-started/resource-types.md
@@ -1,5 +1,5 @@
 ---
-title: Supported Resource Types
+title: Configuration Reference
 order: 3
 ---
 
@@ -16,22 +16,31 @@ This resource type is used to define a database deployment.
 
 #### KurrentDBSpec
 
-| Field                                                   | Required | Description                                                                                                                              |
-|---------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------|
-| `replicas` _integer_                                    | Yes      | Number of nodes in a database cluster.  May be 1, 3, or, for [standalone ReadOnly-Replicas][ror], it may be 0.                            |
-| `image` _string_                                        | Yes      | KurrentDB container image URL                                                                                                            |
-| `resources` _[ResourceRequirements][d1]_                | No       | Database container resource limits and requests                                                                                          |
-| `storage` _[PersistentVolumeClaim][d2]_                 | Yes      | Persistent volume claim settings for the underlying data volume                                                                          |
-| `network` _[KurrentDBNetwork][d3]_                      | Yes      | Defines the network configuration to use with the database                                                                               |
-| `configuration` _yaml_                                  | No       | Additional configuration to use with the database, see [below](#configuring-kurrent-db)                                                  |
-| `sourceBackup` _string_                                 | No       | Backup name to restore a cluster from                                                                                                    |
-| `security` _[KurrentDBSecurity][d4]_                    | No       | Security configuration to use for the database. This is optional, if not specified the cluster will be created without security enabled. |
-| `licenseSecret` _[SecretKeySelector][d5]_               | No       | A secret that contains the Enterprise license for the database                                                                           |
-| `constraints` _[KurrentDBConstraints][d6]_              | No       | Scheduling constraints for the Kurrent DB pod.                                                                                           |
-| `readOnlyReplias` _[KurrentDBReadOnlyReplicasSpec][d7]_ | No       | Read-only replica configuration the Kurrent DB Cluster.                                                                                  |
-| `extraMetadata` _[KurrentDBExtraMetadataSpec][d8]_      | No       | Additional annotations and labels for child resources.                                                                                   |
-| `quorumNodes` _string array_                            | No       | A list of endpoints (in host:port notation) to reach the quorum nodes when .Replicas is zero, see [standalone ReadOnlyReplicas][ror]     |
+| Field                                                    | Required | Description                                                                                                                              |
+|----------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `replicas` _integer_                                     | Yes      | Number of nodes in a database cluster.  May be 1, 3, 5, or, for [standalone ReadOnly-Replicas][ror], it may be 0.                        |
+| `image` _string_                                         | Yes      | KurrentDB container image URL.  See [Selecting An Image][img], below.                                                                    |
+| `resources` _[ResourceRequirements][d1]_                 | No       | Database container resource limits and requests                                                                                          |
+| `storage` _[PersistentVolumeClaim][d2]_                  | Yes      | Persistent volume claim settings for the underlying data volume                                                                          |
+| `network` _[KurrentDBNetwork][d3]_                       | Yes      | Defines the network configuration to use with the database                                                                               |
+| `configuration` _yaml_                                   | No       | Additional configuration to use with the database, see [below](#configuring-kurrent-db)                                                  |
+| `environmentSecret` _string_                             | No       | The name of a Secret to populate environment variables.  If the secret changes a rolling restart occurs.                                 |
+| `sourceBackup` _string_                                  | No       | Backup name to restore a cluster from                                                                                                    |
+| `security` _[KurrentDBSecurity][d4]_                     | No       | Security configuration to use for the database. This is optional, if not specified the cluster will be created without security enabled. |
+| `licenseSecret` _[SecretKeySelector][d5]_                | No       | A secret that contains the Enterprise license for the database                                                                           |
+| `constraints` _[KurrentDBConstraints][d6]_               | No       | Scheduling constraints for the Kurrent DB pod.                                                                                           |
+| `readOnlyReplicas` _[KurrentDBReadOnlyReplicasSpec][d7]_ | No       | Read-only replica configuration for the Kurrent DB Cluster.                                                                              |
+| `archiver` _[KurrentDBArchiverSpec][d8]_                 | No       | Archiver replica configuration for the Kurrent DB Cluster.                                                                               |
+| `extraMetadata` _[KurrentDBExtraMetadataSpec][d9]_       | No       | Additional annotations and labels for child resources.                                                                                   |
+| `quorumNodes` _string array_                             | No       | A list of endpoints (in host:port notation) to reach the quorum nodes when .Replicas is zero, see [standalone ReadOnlyReplicas][ror]     |
+| `serviceAccountName` _string_                            | No       | A ServiceAccount for pods to run as (defaults to `default` in the current namespace).  Useful for IRSA, see [archiver example][arx].     |
+| `telemetryOptOut` _boolean_                              | No       | Opt-out of telemetry in the KurrentDB cluster.                                                                                           |
+| `users` _KurrentDBUsersSpec_                             | No       | Initial user configuration.  No deployment should be considered secure without configure initial user passwords.                         |
+| `configReloadKey` _string_                               | No       | Has no effect, except a change to this value triggers a config reload.  See [Manually Triggering Reload or Restart][trg].                |
+| `rollingRestartKey` _string_                             | No       | Has no effect, except a change to this value triggers a rolling restart.  See [Manually Triggering Reload or Restart][trg].              |
+| `fullRestartKey` _string_                                | No       | Has no effect, except a change to this value triggers a full restart.  See [Manually Triggering Reload or Restart][trg].                 |
 
+[img]: #selecting-an-image
 [d1]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core
 [d2]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimspec-v1-core
 [d3]: #kurrentdbnetwork
@@ -39,8 +48,11 @@ This resource type is used to define a database deployment.
 [d5]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretkeyselector-v1-core
 [d6]: #kurrentdbconstraints
 [d7]: #kurrentdbreadonlyreplicasspec
-[d8]: #kurrentdbextrametadataspec
+[d8]: #kurrentdbarchiverspec
+[d9]: #kurrentdbextrametadataspec
 [ror]: ../operations/database-deployment.md#deploying-standalone-read-only-replicas
+[arx]: ../operations/database-deployment.md#three-node-insecure-cluster-with-archiving
+[trg]: ../operations/modify-deployments.md#manually-triggering-reload-or-restart
 
 #### KurrentDBReadOnlyReplicasSpec
 
@@ -52,11 +64,27 @@ Other than `replicas`, each of the fields in `KurrentDBReadOnlyReplicasSpec` def
 | `resources` _[ResourceRequirements][r1]_     | No       | Database container resource limits and requests.                 |
 | `storage` _[PersistentVolumeClaim][r2]_      | No       | Persistent volume claim settings for the underlying data volume. |
 | `configuration` _yaml_                       | No       | Additional configuration to use with the database.               |
-| `constraints` _[KurrentDBConstraints][r3]_ | No       | Scheduling constraints for the Kurrent DB pod.                   |
+| `constraints` _[KurrentDBConstraints][r3]_   | No       | Scheduling constraints for the Kurrent DB pod.                   |
 
 [r1]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core
 [r2]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimspec-v1-core
 [r3]: #kurrentdbconstraints
+
+#### KurrentDBArchiverSpec
+
+Other than `enabled`, each of the fields in `KurrentDBArchiverSpec` default to the corresponding values from the main KurrentDBSpec.
+
+| Field                                        | Required | Description                                                              |
+|----------------------------------------------|----------|--------------------------------------------------------------------------|
+| `enabled` _bool_                             | No       | If an Archiver node should be added to the cluster.  Defaults to False.  |
+| `resources` _[ResourceRequirements][a1]_     | No       | Database container resource limits and requests.                         |
+| `storage` _[PersistentVolumeClaim][a2]_      | No       | Persistent volume claim settings for the underlying data volume.         |
+| `configuration` _yaml_                       | No       | Additional configuration to use with the database.                       |
+| `constraints` _[KurrentDBConstraints][a3]_   | No       | Scheduling constraints for the Kurrent DB pod.                           |
+
+[a1]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core
+[a2]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimspec-v1-core
+[a3]: #kurrentdbconstraints
 
 #### KurrentDBConstraints
 
@@ -92,13 +120,15 @@ and `HeadlessServices` support "per-node-kind" template expansions:
 - `{name}` expands to KurrentDB.metadata.name
 - `{namespace}` expands to KurretnDB.metadata.namespace
 - `{domain}` expands to the KurrnetDBNetwork.domain
-- `{nodeTypeSuffix}` expands to `""` for a primary node or `"-replica"` for a replica node
+- `{nodeTypeSuffix}` expands to `""` for a quorum node, `"-replica"` for a read-only replica node,
+  or `"-archiver"` for an archiver node.
 
 Additionally, `HeadlessPodServices` and `LoadBalancers` support "per-pod" template expansions:
 - `{name}` expands to KurrentDB.metadata.name
 - `{namespace}` expands to KurretnDB.metadata.namespace
 - `{domain}` expands to the KurrnetDBNetwork.domain
-- `{nodeTypeSuffix}` expands to `""` for a primary node or `"-replica"` for a replica node
+- `{nodeTypeSuffix}` expands to `""` for a quorum node, `"-replica"` for a read-only replica node,
+  or `"-archiver"` for an archiver node.
 - `{podName}` expands to the name of the pod corresponding to the resource
 - `{podOrdinal}` the ordinal assigned to the pod corresponding to the resource
 
@@ -118,11 +148,15 @@ Notably, `Pods` and `PersistentVolumeClaims` do not support any template expansi
 |----------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------|
 | `domain` _string_                            | Yes      | Domain used for external DNS e.g. advertised address exposed in the gossip state                                    |
 | `loadBalancer` _[KurrentDBLoadBalancer][n1]_ | Yes      | Defines a load balancer to use with the database                                                                    |
-| `fqdnTemplate` _string_                      | No       | The template string used to define the external advertised address of a node                                        |
-| `internodeTrafficStrategy` _string_          | No       | How servers dial each other.  One of `"ServiceName"` (default), `"FQDN"`, or `"SplitDNS"`.  See [details][n2]. |
+| `fqdnTemplate` _string_                      | No       | The template string used to define the external advertised address of a node.  See below.                           |
+| `internodeTrafficStrategy` _string_          | No       | How servers dial each other.  One of `"ServiceName"` (default), `"FQDN"`, or `"SplitDNS"`.  See [details][n2].      |
 | `clientTrafficStrategy` _string_             | No       | How clients dial servers.  One of `"ServiceName"` or `"FQDN"` (default).  See [details][n2].                        |
 | `splitDNSExtraRules` _list of [DNSRule][n3]_ | No       | Advanced configuration for when `internodeTrafficStrategy` is set to `"SplitDNS"`.                                  |
+| `nodePort` _integer_                         | No       | The HTTP port that KurrentDB listens on.  Defaults to 2113.  For priviliged ports, see below.                       |
+| `replicationPort` _integer_                  | No       | The TCP port for replication traffic from other nodes.  Defaults to 1112.  For priviliged ports, see below.         |
+| `nodeTcpPort` _integer_                      | No       | The TCP port for legacy TCP client traffic.  Defaults to 1113.  For priviliged ports, see below.                    |
 
+[n0]: #KurrentDBNetwork
 [n1]: #kurrentdbloadbalancer
 [n2]: ../operations/advanced-networking.md#traffic-strategy-options
 [n3]: #dnsrule
@@ -131,10 +165,17 @@ Note that `fqdnTemplate` supports the following expansions:
 - `{name}` expands to KurrentDB.metadata.name
 - `{namespace}` expands to KurretnDB.metadata.namespace
 - `{domain}` expands to the KurrnetDBNetwork.domain
-- `{nodeTypeSuffix}` expands to `""` for a primary node or `"-replica"` for a replica node
+- `{nodeTypeSuffix}` expands to `""` for a quorum node, `"-replica"` for a read-only replica node,
+  or `"-archiver"` for an archiver node.
 - `{podName}` expands to the name of the pod
 
 When `fqdnTemplate` is empty, it defaults to `{podName}.{name}{nodeTypeSuffix}.{domain}`.
+
+The ports for `nodePort`, `replicationPort`, and `nodeTcpPort` may be chosen arbitrarily, but note
+that the Operator always runs nodes as non-root.  Therefore, to utilize priviliged ports (port
+numbers less than 1024), you will need to use images with `setcap cap_net_bind_service+ep` applied
+to the `kurrentd` binary inside the image.  Kurrent offers Red Hat-certified images which meet this
+criteria, see [Selecting An Image][img], below.
 
 #### DNSRule
 
@@ -169,15 +210,23 @@ regex: true
 |------------------------------|----------|--------------------------------------------------------------------------------|
 | `enabled` _boolean_          | Yes      | Determines if a load balancer should be deployed for each node                 |
 | `allowedIps` _string array_  | No       | List of IP ranges allowed by the load balancer (default will allow all access) |
+| `loadBalancerClass` _string_ | No       | The `Service.spec.loadBalancerClass` to use.  Defaults to empty.               |
+
+Note that changing the `loadBalancerClass` will require deleting the old load balancer Service completely and recreating it (which make take a while) because `loadBalancerClass` is an immutable field of a Service.
 
 #### KurrentDBSecurity
 
 | Field                                                                  | Required | Description                                                                                                           |
 |------------------------------------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------|
 | `certificateReservedNodeCommonName` _string_                           | No       | Common name for the TLS certificate (this maps directly to the database property `CertificateReservedNodeCommonName`) |
-| `certificateAuthoritySecret` _[CertificateSecret](#certificatesecret)_ | No       | Secret containing the CA TLS certificate.                                                                             |
-| `certificateSecret` _[CertificateSecret](#certificatesecret)_          | Yes      | Secret containing the TLS certificate to use.                                                                         |
+| `certificateAuthoritySecret` _[CertificateSecret](#certificatesecret)_ | No       | Secret containing the CA TLS certificate.  Updates trigger a config reload.  Only `.name` is required; See below.     |
+| `certificateSecret` _[CertificateSecret](#certificatesecret)_          | Yes      | Secret containing the TLS certificate to use.  Updates trigger a config reload.                                       |
 | `certificateSubjectName` _string_                                      | No       | Deprecated field.  The value of this field is always ignored.                                                         |
+
+Note that in `certificateAuthoritySecret`, only `.name` is required.  `.keyName` is optional; if
+provided only that Secret key will be mounted into the pod as a CA.  If not provided, all Secret
+keys will be mounted as CAs, which allows for rotating CAs without downtime, by trusting both old
+and new CAs for a period of time.  `.privateKeyName` is deprecated and ignored.
 
 #### CertificateSecret
 
@@ -187,6 +236,43 @@ regex: true
 | `keyName` _string_        | Yes      | Key within the secret containing the TLS certificate             |
 | `privateKeyName` _string_ | No       | Key within the secret containing the TLS certificate private key |
 
+#### KurrentDBUsersSpec
+
+| Field                                          | Required | Description                                          |
+|------------------------------------------------|----------|------------------------------------------------------|
+| adminPasswordSecret _[SecretKeySelector][u1]_  | Yes      | Secret containing initial password for `admin` user. |
+| opsPasswordSecret _[SecretKeySelector][u1]_    | Yes      | Secret containing initial password for `ops` user.   |
+| customUsers _[KurrentDBUserSpec][u2] array_    | No       | Custom users to add to the database.                 |
+
+The `admin` and `ops` passwords are required if users are configured at all.  Those paswords are set
+by initial database creation; when set, the database will never accept the default password
+(`changeit)`.  No deployment should be considered secure without configuring these two passwords.
+
+The additioanl users described in `customUsers` are optional, and are configured by the Operator
+after the first successful health check.
+
+The Operator does not currently support updates to the intial user configuration.  The Secrets
+referenced here are not read after the first time the KurrentDB cluster reaches a healhty state,
+and may safely be deleted.
+
+[u1]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretkeyselector-v1-core
+[u2]: #kurrentdbuserspec
+
+#### KurrentDBUserSpec
+
+| Field                                    | Required | Description                                        |
+|------------------------------------------|----------|----------------------------------------------------|
+| loginName _string_                       | Yes      | The login name of the user.                        |
+| fullName _string_                        | Yes      | The display name of the user.                      |
+| passwordSecret _[SecretKeySelector][u1]_ | Yes      | The Secret from which the password should be read. |
+| groups _string array_                    | No       | Additional groups to add user to, see below.       |
+
+Note that KurrentDB always adds every new user to a group matching its login name, so the groups
+listed in `.groups` are in addition to that default behavior.
+
+The Operator does not currently support updates to the intial user configuration.  The Secrets
+referenced here are not read after the first time the KurrentDB cluster reaches a healhty state,
+and may safely be deleted.
 
 ## KurrentDBBackup
 
@@ -241,11 +327,39 @@ Note that the only metadata allowed in `template.metadata` is `name`, `labels`, 
 If `name` is provided, it will be extended with an index like `my-name-1` when creating backups,
 otherwise created backups will be based on the name of the schedule resource.
 
-## Configuring Kurrent DB
+## Selecting an Image
 
-The [`KurrentDB.spec.configuration` yaml field](#kurrentdbspec) may contain any valid configuration values for Kurrent
-DB.  However, some values may be unnecessary, as the Operator provides some defaults, while other
-values may be ignored, as the Operator may override them.
+When selecting a KurrentDB image, you may choose from one of Kurrent's standard images:
+
+| Versions           | Image                                                    | Link        |
+|--------------------|----------------------------------------------------------|-------------|
+| 23.10.x to 24.10.x | `docker.eventstore.com/eventstore/eventstoredb-ee:X.Y.Z` | [link][old] |
+| 25.0.0 and greater | `docker.kurrent.io/kurrent-latest/kurrentdb:X.Y.Z`       | [link][std] |
+
+Additionally, Kurrent offers Red Hat-certified KurrentDB images.  These images have the additional
+property that they have `setcap cap_net_bind_service+ep` applied to the `kurrentd` binary inside the
+image, which allows them to be used in conjunction with setting `.spec.network.nodePort` to a
+privileged port, like 443.
+
+These same images without the Red Hat Certification (or official Red Hat sha256 checks) are
+available without a Red Hat account directly from Kurrent.  This is useful if you want the
+`setcap`-enabled image but don't care about the Red Hat Certification.
+
+| Versions           | Certified | Image                                                    | Link        |
+|--------------------|-----------|----------------------------------------------------------|-------------|
+| 25.0.0 and greater | Yes       | `registry.connect.redhat.com/kurrent-io/kurrentdb:X.Y.Z` | [link][rhc] |
+| 25.0.0 and greater | No        | `docker.kurrent.io/kurrent-latest/kurrentdb-rhel8:X.Y.Z` | [link][pre] |
+
+[old]: https://cloudsmith.io/~eventstore/repos/eventstore/packages/?q=format%3Adocker+name%3Aeventstoredb-ee
+[std]: https://cloudsmith.io/~eventstore/repos/kurrent-latest/packages/?q=format%3Adocker+name%3Akurrentdb
+[rhc]: https://catalog.redhat.com/en/software/containers/kurrent-io/kurrentdb/690a11e9b1dedf2b2890ef75
+[pre]: https://cloudsmith.io/~eventstore/repos/kurrent-latest/packages/?q=format%3Adocker+name%3Akurrentdb-rhel8
+
+## Configuring KurrentDB
+
+The [`KurrentDB.spec.configuration` yaml field](#kurrentdbspec) may contain any valid configuration
+values for Kurrent DB.  However, some values may be unnecessary, as the Operator provides some
+defaults, while other values may be ignored, as the Operator may override them.
 
 The Operator-defined default configuration values, which may be overridden by the user's
 `KurrentDB.spec.configuration` are:
@@ -287,4 +401,7 @@ The Operator-managed configuration values, which take precedence over the user's
 | AdveritseHostToClientAs      | Derived from `KurrentDB.spec.newtork.fqdnTemplate`           |
 | ClusterSize                  | Derived from `KurrentDB.spec.replicas`                       |
 | GossipSeed                   | Derived from pod list                                        |
-| ReadOnlyReplica              | Automatically set for ReadOnlyReplica pods                   |
+| ReadOnlyReplica              | Automatically set for ReadOnlyReplica and Archiver pods      |
+| NodePort                     | Derived from `KurrentDB.spec.network.nodePort`               |
+| ReplicationPort              | Derived from `KurrentDB.spec.network.replicationPort`        |
+| NodeTcpPort                  | Derived from `KurrentDB.spec.network.nodeTcpPort`            |

--- a/docs/server/kubernetes-operator/v1.5.0/operations/modify-deployments.md
+++ b/docs/server/kubernetes-operator/v1.5.0/operations/modify-deployments.md
@@ -116,3 +116,29 @@ The steps that the Operator takes to increase the number of read-only replicas a
 
 - Take a VolumeSnapshot of a primary node.
 - Start new read-only replica node(s) based on that snapshot.
+
+Since an archiver node is a special kind of read-only replica, the logic for enabling or disabling
+an archiver is identical to the read-only replica logic.
+
+## Manually Triggering Reload or Restart
+
+The Operator will automatically trigger a configuration reload, a rolling restart, or a full restart
+(where all nodes are brought down before bringing them back up) whenever it is required.  For
+example, a configuration reload happens automatically when the database log level is changed or a
+TLS certificate or certificate authority is changed, since those are the only hot-reloadable
+configurations.  Full restarts are triggered any time that a rolling restart would not be possible,
+such as converting an insecure cluster to a secure cluster, when old nodes and new nodes would not
+be able to talk to each other.
+
+Additionally, the Operator allows you to manually trigger any of those operations by altering one
+of:
+
+- `KurrentDB.spec.configReloadKey`
+- `KurrentDB.spec.rollingRestartKey`
+- `KurrentDB.spec.fullRestartKey`
+
+Each key starts as an empty string and each time a key is changed, the corresponding operation will
+be executed.  Administrators may safely ignore these settings.  Still, they may prove useful in
+specific scenarios, such as evaluating the Operator, or testing application performance while the
+database executes a rolling restart in a staging environment, before applying a reconfiguration to
+the production environment.

--- a/docs/server/kubernetes-operator/versions.json
+++ b/docs/server/kubernetes-operator/versions.json
@@ -5,6 +5,11 @@
     "group": "Kubernetes Operator",
     "versions": [
       {
+        "path": "kubernetes-operator/v1.5.0",
+        "version": "v1.5.0",
+        "startPage": "getting-started/"
+      },
+      {
         "path": "kubernetes-operator/v1.4.3",
         "version": "v1.4.3",
         "startPage": "getting-started/"


### PR DESCRIPTION
### **User description**
## Description

This is the reviewable content delta PR, set to merge into the "big copy" pr (#940), which will merge into master.

## Page previews

<!-- Add the specific pages that your PR changes here -->


___

### **PR Type**
Documentation


___

### **Description**
- Update Kubernetes Operator documentation from v1.4.3 to v1.5.0

- Add comprehensive features for v1.5.0 including Archiver nodes, TLS certificate management, user configuration, and 5-node cluster support

- Expand configuration reference with new fields for archiver, users, service accounts, telemetry, and manual restart triggers

- Add new deployment examples for archiving and secure clusters with user management

- Update installation instructions and version references throughout documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["v1.4.3 Docs"] -->|Version Update| B["v1.5.0 Docs"]
  B -->|Add Features| C["Archiver Nodes"]
  B -->|Add Features| D["User Management"]
  B -->|Add Features| E["TLS Auto-reload"]
  B -->|Add Features| F["5-node Clusters"]
  B -->|Add Features| G["Manual Restart Keys"]
  C -->|Example| H["Archiving Deployment"]
  D -->|Example| I["Secure Cluster with Users"]
  E -->|Config| J["Certificate Authority Updates"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update version in page title</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/v1.5.0/README.md

- Update title from v1.4.3 to v1.5.0


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/941/files#diff-28ac40ab9c41a603670716e372115f385749f0474670ff019510c7a48431ff82">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add v1.5.0 release notes with major features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/v1.5.0/getting-started/README.md

<ul><li>Replace v1.4.0-1.4.3 release notes with comprehensive v1.5.0 feature <br>list<br> <li> Add support for Archiver nodes with blob storage offloading<br> <li> Add TLS certificate auto-reload capability with zero downtime<br> <li> Add initial user and password configuration management<br> <li> Add support for 5-node clusters and multiple certificate authorities<br> <li> Add telemetry opt-out, loadBalancerClass, NodePort configuration, and <br>manual restart triggers<br> <li> Reformat text for better readability with line wrapping</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/941/files#diff-078c50623ba3ff5b7f8a814f7486c2fdb2cc1bebf9c19e2298111e06e3a97afa">+45/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>installation.md</strong><dd><code>Update version references in installation guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/v1.5.0/getting-started/installation.md

<ul><li>Update Helm chart version from 1.4.3 to 1.5.0 in installation examples<br> <li> Update startingCSV version from 1.4.3 to 1.5.0 for OLM installation<br> <li> Update version references in upgrade instructions</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/941/files#diff-3f09db2456d69467c027ae0d110bae1fce2f6bccebfd78debc9fb0158d0ac997">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resource-types.md</strong><dd><code>Expand configuration reference with v1.5.0 features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/v1.5.0/getting-started/resource-types.md

<ul><li>Rename page title from "Supported Resource Types" to "Configuration <br>Reference"<br> <li> Add support for 5-node clusters in <code>replicas</code> field documentation<br> <li> Add new fields: <code>EnvironmentSecret</code>, <code>archiver</code>, <code>serviceAccountName</code>, <br><code>telemetryOptOut</code>, <code>users</code>, and restart trigger keys<br> <li> Add new <code>KurrentDBArchiverSpec</code> section with archiver node configuration <br>options<br> <li> Add new <code>KurrentDBUsersSpec</code> and <code>KurrentDBUserSpec</code> sections for user <br>management<br> <li> Add <code>loadBalancerClass</code> field to <code>KurrentDBLoadBalancer</code> section<br> <li> Enhance <code>KurrentDBSecurity</code> documentation for automatic TLS certificate <br>updates and multiple CA support<br> <li> Add <code>nodePort</code>, <code>replicationPort</code>, and <code>nodeTcpPort</code> fields to <br><code>KurrentDBNetwork</code> section<br> <li> Add new "Selecting An Image" section with image registry options and <br>Red Hat certified images<br> <li> Update template expansion documentation to include archiver node type <br>suffix<br> <li> Add privileged port configuration guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/941/files#diff-d7f6f99c7357472d8c67d464fbd157162bd29397385366e0a66402c58645427c">+137/-20</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database-deployment.md</strong><dd><code>Add archiving and user configuration deployment examples</code>&nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/v1.5.0/operations/database-deployment.md

<ul><li>Add new deployment example for three-node cluster with archiving<br> <li> Add archiver node configuration with S3 storage and IRSA support<br> <li> Add user configuration examples to secure cluster deployments<br> <li> Add password secrets for admin, ops, and custom users<br> <li> Reorganize examples with improved descriptions and links<br> <li> Update terminology from "instance" to "deployment" for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/941/files#diff-bec7bdd13c1734a1830c2a57255d9d8fe128b6043ee14ceb1d3c44e4550ccaae">+137/-31</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>modify-deployments.md</strong><dd><code>Add manual restart trigger documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/v1.5.0/operations/modify-deployments.md

<ul><li>Add new section "Manually Triggering Reload or Restart" explaining <br>manual restart keys<br> <li> Document <code>configReloadKey</code>, <code>rollingRestartKey</code>, and <code>fullRestartKey</code> fields<br> <li> Explain use cases for manual restart triggers in testing and <br>evaluation scenarios<br> <li> Add note about archiver node restart logic being identical to <br>read-only replicas</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/941/files#diff-e0e9fa09b202f56c91ae3ee9e21f7152f464e1622c1d0804bd8864b0592bf9ff">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>versions.json</strong><dd><code>Add v1.5.0 to version registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/server/kubernetes-operator/versions.json

<ul><li>Add v1.5.0 as the first entry in the versions list<br> <li> Maintain v1.4.3 as the second entry for backward compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/941/files#diff-aaa62a750c5ba2e0ff71be5e16c58483ff22d6b20a8472a61fbb720825af05ec">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

