### PR TITLE
Fix DocSearch layout shift by unsetting container min-width (ADV-183)

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -84,6 +84,10 @@ html[data-theme="dark"] #kapa-widget-portal {
   text-align: center;
 }
 
+#docsearch-container {
+  min-width: unset !important;
+}
+
 .DocSearch-Button-Keys {
   display: none;
 }


### PR DESCRIPTION
### User description

Refs ADV-183

## Problem

DocSearch React applies a `min-width` to `#docsearch-container` when focused/open, causing a persistent layout shift in the header.

## Fix

Override the default style to keep the search bar width stable:


___

### **PR Type**
Bug fix


___

### **Description**
- Override DocSearch container min-width to prevent layout shift

- Apply unset style with !important to maintain stable search bar width


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DocSearch applies min-width"] -->|causes| B["Layout shift in header"]
  C["Override with min-width unset"] -->|prevents| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.scss</strong><dd><code>Add CSS override for DocSearch container width</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.vuepress/styles/index.scss

<ul><li>Added CSS rule for <code>#docsearch-container</code> selector<br> <li> Set <code>min-width: unset !important</code> to override DocSearch default styling<br> <li> Prevents layout shift caused by DocSearch's min-width application on <br>focus/open</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/943/files#diff-519df9e54451eec19d0d55e2cdea80c9b75620cb871d980f016e279374c7bde8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

