### PR TITLE
[ADV-183] Fix DocSearch layout shift by unsetting container min-width

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -84,6 +84,10 @@ html[data-theme="dark"] #kapa-widget-portal {
   text-align: center;
 }
 
+#docsearch-container {
+  min-width: unset !important;
+}
+
 .DocSearch-Button-Keys {
   display: none;
 }


### PR DESCRIPTION
### **User description**
## Problem

DocSearch applies a `min-width` to `#docsearch-container` when focused/open, causing a persistent layout shift in the header.

## Fix

Override the default style to keep the search bar width stable.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes DocSearch layout shift by unsetting container min-width

- Prevents persistent header width changes when search is focused


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DocSearch container<br/>with min-width"] -- "override with<br/>unset !important" --> B["Stable search bar<br/>width"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.scss</strong><dd><code>Override DocSearch container min-width style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.vuepress/styles/index.scss

<ul><li>Added CSS rule to unset <code>min-width</code> on <code>#docsearch-container</code> element<br> <li> Uses <code>!important</code> flag to override DocSearch default styles<br> <li> Prevents layout shift when search bar is focused or opened</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/944/files#diff-519df9e54451eec19d0d55e2cdea80c9b75620cb871d980f016e279374c7bde8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

