### PR TITLE
Replace flat sitemap llms.txt with curated, AI-optimized index

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -14,6 +14,7 @@ import {linkCheckPlugin} from "./markdown/linkCheck";
 import {replaceLinkPlugin} from "./markdown/replaceLink";
 import {importCodePlugin} from "./markdown/xode/importCodePlugin";
 import {llmsPlugin} from '@vuepress/plugin-llms'
+import {getLlmsPluginOptions} from "./configs/llms";
 import fs from 'fs';
 
 const searchInterceptor = fs.readFileSync(path.join(__dirname, 'util/searchInterceptor.js'), 'utf8');
@@ -123,5 +124,5 @@ export default defineUserConfig({
         "@theme-hope/components/BreadCrumb": path.resolve(__dirname, "./components/breadCrumb.ts"),
         "@theme-hope/modules/info/components/TOC": path.resolve(__dirname, "./components/TocWithFeedback.ts"),
     },
-    plugins: [llmsPlugin()],
+    plugins: [llmsPlugin(getLlmsPluginOptions(ver))],
 });

--- a/docs/.vuepress/configs/llms.ts
+++ b/docs/.vuepress/configs/llms.ts
@@ -310,9 +310,10 @@ export function getLlmsPluginOptions(versioning: Versioning) {
   const latestServer = versioning.latest; // e.g. "server/v26.0"
   const latestServerPrefix = `/${latestServer}/`;
   const opGroup = versioning.versions.find((v) => v.id === "kubernetes-operator");
-  const latestOperatorPrefix = opGroup
-    ? `/${opGroup.basePath}/${opGroup.versions[0].path}/`
-    : "";
+  const latestOperatorPrefix =
+    opGroup && opGroup.versions.length > 0
+      ? `/${opGroup.basePath}/${opGroup.versions[0].path}/`
+      : "";
 
   // --- Overview: home, getting-started intro and key pages ---
   const overview: TemplateGetter = (pages, state) => {

--- a/docs/.vuepress/configs/llms.ts
+++ b/docs/.vuepress/configs/llms.ts
@@ -539,7 +539,7 @@ export function getLlmsPluginOptions(versioning: Versioning) {
    */
   const CURATED_TEMPLATE = `# Kurrent Docs – Human-Readable Index for AI (llms.txt)
 
-Kurrent is the event-native data platform (database formerly known as EventStoreDB), built for event sourcing, CQRS, and event-driven architecture. This file points to the most important documentation sections for KurrentDB, ordered by importance for understanding and using KurrentDB. These links reflect authoritative, up-to-date docs from docs.kurrent.io.
+KurrentDB is the event-native stream database for event sourcing, CQRS, and event-driven architecture. In this documentation set, use "EventStoreDB" when referring to EventStoreDB ≤ 24.x content and "KurrentDB" for 25.0+ content. This file points to the most important documentation sections, ordered by importance for understanding and using KurrentDB. These links reflect authoritative, up-to-date docs from docs.kurrent.io.
 
 For exhaustive coverage (all documentation pages in one file), use \`llms-full.txt\` at the same base URL (e.g. \`${baseUrl}/llms-full.txt\`). LLMs and tooling that need the complete list of docs can fetch that file instead.
 

--- a/docs/.vuepress/configs/llms.ts
+++ b/docs/.vuepress/configs/llms.ts
@@ -1,0 +1,649 @@
+/**
+ * @fileoverview Curated LLMs plugin configuration for Kurrent documentation.
+ *
+ * This module configures the VuePress LLMs plugin to generate a structured `llms.txt`
+ * file instead of a flat list of all documentation links. The output is organized by
+ * importance for LLMs: overview and core concepts first, then client libraries and APIs,
+ * then configuration, deployment, operations, and reference sections.
+ *
+ * Key behaviors:
+ * - Uses full URLs (domain from baseUrl, e.g. https://docs.kurrent.io).
+ * - Sections are built from versioned paths (latest server, latest Kubernetes operator).
+ * - Descriptions come from frontmatter or theme excerpts; broken index URLs are normalized.
+ * - HTTP API Security appears only under APIs (excluded from Security & Access Control).
+ *
+ * The template placeholders (e.g. {overview}, {concepts}) are filled by getter functions
+ * that filter and order pages from the build. See getLlmsPluginOptions and the factory
+ * helpers: createPrefixSection, createSlugOrderSection, createFilterSection.
+ */
+
+import type { TemplateGetter, TemplateGetterOptions } from "@vuepress/plugin-llms";
+import type { LLMPage, LLMState } from "@vuepress/plugin-llms";
+import { generateLink } from "@vuepress/plugin-llms";
+import type { Versioning } from "../lib/versioning";
+import { baseUrl } from "./plugins/shared";
+
+// ---------------------------------------------------------------------------
+// URL and description helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Detects URLs that end with `/.md` (broken index links produced by the plugin).
+ *
+ * @param url - Generated link URL (e.g. from generateLink).
+ * @returns true if the URL ends with `/.md`.
+ */
+function isBrokenIndexUrl(url: string): boolean {
+  return /\/\.md$/i.test(url);
+}
+
+/**
+ * Converts a broken index URL (e.g. `.../quick-start/.md`) to a valid one
+ * (`.../quick-start/index.md`). Used in Core Concepts so index pages like
+ * connectors and projections are included with working links.
+ *
+ * @param url - Generated link URL that may end with `/.md`.
+ * @returns URL with `/.md` replaced by `/index.md`.
+ */
+function normalizeIndexUrl(url: string): string {
+  return url.replace(/\/\.md$/i, "/index.md");
+}
+
+/**
+ * Returns the description text for a page for use in llms.txt link lines.
+ * Prefers frontmatter `description`; falls back to theme-generated `excerpt`.
+ * Trailing ellipses from excerpts are stripped.
+ *
+ * To control what appears in llms.txt, add to a page's YAML frontmatter:
+ *   description: Full summary for LLMs and search (no truncation).
+ *
+ * @param p - LLMPage (with optional excerpt and frontmatter).
+ * @returns Description string or undefined if none available.
+ */
+function getPageDescription(p: LLMPage): string | undefined {
+  const page = p as LLMPage & { excerpt?: string; frontmatter?: { description?: string } };
+  const fromFrontmatter = page.frontmatter?.description?.trim();
+  const fromExcerpt = page.excerpt?.trim();
+  if (fromFrontmatter) return fromFrontmatter;
+  if (fromExcerpt) return fromExcerpt.replace(/\s*\.\.\.\s*$/, "");
+  return undefined;
+}
+
+/**
+ * Formats an array of pages as markdown list items: `- [Title](url): description`.
+ * Skips pages whose generated URL is broken (isBrokenIndexUrl). Newlines in
+ * descriptions are replaced with ": " so the output stays one line per link.
+ *
+ * @param pages - Pages to format.
+ * @param state - LLM state (used by generateLink).
+ * @returns Multi-line string of list items, or empty string if no valid links.
+ */
+function formatLinkWithDescription(pages: LLMPage[], state: LLMState): string {
+  return pages
+    .map((p) => {
+      const url = generateLink(p.path, state);
+      if (isBrokenIndexUrl(url)) return null;
+      const title = (p as LLMPage & { title?: string }).title ?? "Documentation";
+      const desc = getPageDescription(p);
+      return desc
+        ? `- [${title}](${url}): ${desc.replace(/\n/g, ": ")}`
+        : `- [${title}](${url})`;
+    })
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Client libraries section: supported languages and link formatting
+// ---------------------------------------------------------------------------
+
+/** Client path segments we include (legacy TCP and other deprecated clients are excluded). */
+const CLIENT_BASES = ["dotnet", "golang", "java", "node", "python", "rust"] as const;
+
+/** Display labels for each client base (e.g. "golang" → "Go"). */
+const CLIENT_LABELS: Record<string, string> = {
+  dotnet: ".NET",
+  golang: "Go",
+  java: "Java",
+  node: "Node.js",
+  python: "Python",
+  rust: "Rust",
+  tcp: "TCP (deprecated)",
+};
+
+/**
+ * Extracts the client base from a path (e.g. `/clients/dotnet/v1.2.0/...` → "dotnet").
+ *
+ * @param path - Page path.
+ * @returns First segment after `/clients/` or empty string.
+ */
+function getClientBase(path: string): string {
+  return path.match(/^\/clients\/([^/]+)/)?.[1] ?? "";
+}
+
+/**
+ * True if the path is a client page we want in the Client Libraries section:
+ * one of CLIENT_BASES and one of getting-started, reading-events, appending-events.
+ * Paths under /legacy/ are not wanted.
+ */
+function isWantedClientPage(path: string): boolean {
+  const base = getClientBase(path);
+  if (!CLIENT_BASES.includes(base as (typeof CLIENT_BASES)[number])) return false;
+  return (
+    path.includes("getting-started") ||
+    path.includes("reading-events") ||
+    path.includes("appending-events")
+  );
+}
+
+/**
+ * Formats a single client page as a list item: `- [Language – Title](url): description`.
+ * Returns null if the generated URL is broken (skipped in output).
+ */
+function formatClientLink(p: LLMPage, state: LLMState): string | null {
+  const url = generateLink(p.path, state);
+  if (isBrokenIndexUrl(url)) return null;
+  const base = getClientBase(p.path);
+  const label = CLIENT_LABELS[base] ?? base;
+  const title = (p as LLMPage & { title?: string }).title ?? "Documentation";
+  const desc = getPageDescription(p);
+  const suffix = desc ? `: ${desc.replace(/\n/g, ": ")}` : "";
+  return `- [${label} – ${title}](${url})${suffix}`;
+}
+
+// ---------------------------------------------------------------------------
+// Section getter factories (used by getLlmsPluginOptions)
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a section getter that includes all pages under a path prefix, optionally
+ * sorted by path and limited in count. Used for Cloud, Kubernetes Operator,
+ * and Connectors Sinks.
+ *
+ * @param prefix - Path prefix (e.g. `/cloud/` or `/server/v26.0/features/connectors/sinks/`).
+ * @param options - limit: max links (default 25); includeBase: include page with path === prefixBase (default true); sort: sort by path (default true).
+ * @returns TemplateGetter that returns formatted list or "" when prefix is empty (e.g. no operator version).
+ */
+function createPrefixSection(
+  prefix: string,
+  options: { limit?: number; includeBase?: boolean; sort?: boolean } = {}
+): TemplateGetter {
+  const { limit = 25, includeBase = true, sort = true } = options;
+  const prefixBase = prefix.replace(/\/$/, "");
+  return (pages, state) => {
+    if (!prefix) return "";
+    const filtered = pages.filter(
+      (p) =>
+        (includeBase && p.path === prefixBase) || p.path.startsWith(prefix)
+    );
+    const list = sort
+      ? [...filtered].sort((a, b) => a.path.localeCompare(b.path))
+      : filtered;
+    return formatLinkWithDescription(list.slice(0, limit), state);
+  };
+}
+
+/**
+ * Returns true when the page is the index/overview page for a segment (e.g. quick-start,
+ * configuration). Reusable so slug-order sections don’t repeat the same index logic.
+ */
+function matchIndexSlug(
+  p: LLMPage,
+  prefix: string,
+  prefixBase: string,
+  segment: string
+): boolean {
+  return (
+    p.path === prefix ||
+    p.path === prefixBase ||
+    p.path.endsWith(`/${segment}`) ||
+    p.path.includes(`${segment}/index`)
+  );
+}
+
+/**
+ * Builds a section getter that selects exactly one page per slug in a fixed order,
+ * using a custom matcher. Used for Installation, APIs, Configuration, and Diagnostics
+ * where we want a curated order (e.g. index, then cluster, networking, db-config).
+ *
+ * @param prefix - Path prefix for candidate pages.
+ * @param slugOrder - Ordered list of slugs; for each slug, the first matching page is chosen.
+ * @param matchSlug - (slug, page, prefix, prefixBase) => true if this page matches the slug (e.g. index slug may match prefix or prefixBase).
+ * @param options - exclude: optional predicate to remove pages from candidates before matching (e.g. exclude whatsnew for installation).
+ * @returns TemplateGetter that returns formatted list of selected pages in slug order.
+ */
+function createSlugOrderSection(
+  prefix: string,
+  slugOrder: string[],
+  matchSlug: (
+    slug: string,
+    page: LLMPage,
+    prefix: string,
+    prefixBase: string
+  ) => boolean,
+  options?: { exclude?: (p: LLMPage) => boolean }
+): TemplateGetter {
+  const prefixBase = prefix.replace(/\/$/, "");
+  const exclude = options?.exclude;
+  return (pages, state) => {
+    let candidates = pages.filter(
+      (p) => p.path.startsWith(prefix) || p.path === prefixBase
+    );
+    if (exclude) candidates = candidates.filter((p) => !exclude(p));
+    const selected: LLMPage[] = [];
+    for (const slug of slugOrder) {
+      const page = candidates.find((p) =>
+        matchSlug(slug, p, prefix, prefixBase)
+      );
+      if (page && !selected.some((x) => x.path === page.path))
+        selected.push(page);
+    }
+    return formatLinkWithDescription(selected, state);
+  };
+}
+
+/**
+ * Builds a section getter that includes all pages matching a predicate, up to a limit.
+ * Optional sortBy gives stable ordering (e.g. by path) instead of VuePress page order.
+ * Used for Tutorials where we filter by path keywords and cap the number of links.
+ *
+ * @param filter - Predicate to include a page (e.g. path includes "tutorials").
+ * @param limit - Maximum number of links to include.
+ * @param options - sortBy: optional comparator for stable order (e.g. (a, b) => a.path.localeCompare(b.path)).
+ * @returns TemplateGetter that returns formatted list.
+ */
+function createFilterSection(
+  filter: (p: LLMPage) => boolean,
+  limit: number,
+  options?: { sortBy?: (a: LLMPage, b: LLMPage) => number }
+): TemplateGetter {
+  const sortBy = options?.sortBy;
+  return (pages, state) => {
+    let candidates = pages.filter(filter);
+    if (sortBy) candidates = [...candidates].sort(sortBy);
+    return formatLinkWithDescription(candidates.slice(0, limit), state);
+  };
+}
+
+/**
+ * Builds a section getter that filters pages by predicate, then picks one page per slug
+ * in a fixed order (first match wins). Used for Security and Release Notes where
+ * candidates span a prefix but we want deliberate slug order instead of positional slice.
+ *
+ * @param filter - Predicate to include a page (e.g. path includes "security", exclude "http-api").
+ * @param slugOrder - Ordered list of slugs; for each slug, the first matching page is chosen.
+ * @param matchSlug - (slug, page) => true if this page matches the slug.
+ * @returns TemplateGetter that returns formatted list in slug order.
+ */
+function createFilterSlugOrderSection(
+  filter: (p: LLMPage) => boolean,
+  slugOrder: string[],
+  matchSlug: (slug: string, page: LLMPage) => boolean
+): TemplateGetter {
+  return (pages, state) => {
+    const candidates = pages.filter(filter);
+    const selected: LLMPage[] = [];
+    for (const slug of slugOrder) {
+      const page = candidates.find((p) => matchSlug(slug, p));
+      if (page && !selected.some((x) => x.path === page.path))
+        selected.push(page);
+    }
+    return formatLinkWithDescription(selected, state);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Version-derived prefixes (used by section getters)
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the VuePress LLMs plugin options for a curated llms.txt: categorized sections,
+ * full domain URLs, and section order by importance for LLMs. Uses the provided versioning
+ * to resolve latest server and latest Kubernetes operator paths.
+ *
+ * @param versioning - Versioning instance (from docs/.vuepress/lib/versioning); provides
+ *   versioning.latest (e.g. "server/v26.0") and versioning.versions for operator path.
+ * @returns Plugin options object: domain, llmsTxt, llmsFullTxt, llmsPageTxt,
+ *   llmsTxtTemplate (markdown with placeholders), llmsTxtTemplateGetter (map of placeholder name → getter).
+ */
+export function getLlmsPluginOptions(versioning: Versioning) {
+  const latestServer = versioning.latest; // e.g. "server/v26.0"
+  const latestServerPrefix = `/${latestServer}/`;
+  const opGroup = versioning.versions.find((v) => v.id === "kubernetes-operator");
+  const latestOperatorPrefix = opGroup
+    ? `/${opGroup.basePath}/${opGroup.versions[0].path}/`
+    : "";
+
+  // --- Overview: home, getting-started intro and key pages ---
+  const overview: TemplateGetter = (pages, state) => {
+    const paths = [
+      "/",
+      "/getting-started/",
+      "getting-started/introduction",
+      "getting-started/kurrent-ecosystem",
+      "getting-started/kurrent-why",
+      "getting-started/concepts",
+    ];
+    const candidates = pages.filter((p) =>
+      paths.some(
+        (path) =>
+          p.path === path ||
+          (path !== "/" && path !== "/getting-started/" && p.path.includes(path))
+      )
+    );
+    return formatLinkWithDescription(candidates.slice(0, 10), state);
+  };
+
+  // --- Installation & Deployment: quick-start (index, installation, default-directories, upgrade-guide); exclude whatsnew ---
+  const installation: TemplateGetter = createSlugOrderSection(
+    latestServerPrefix + "quick-start/",
+    ["index", "installation", "default-directories", "upgrade-guide"],
+    (slug, p, prefix, prefixBase) =>
+      slug === "index"
+        ? matchIndexSlug(p, prefix, prefixBase, "quick-start")
+        : p.path.includes(slug),
+    { exclude: (p) => p.path.includes("whatsnew") }
+  );
+
+  // --- Client Libraries: non-legacy clients only; up to 3 pages per language (getting-started, reading-events, appending-events) ---
+  const clients: TemplateGetter = (pages, state) => {
+    const clientPages = pages
+      .filter(
+        (p) =>
+          p.path.startsWith("/clients/") &&
+          !p.path.includes("/legacy/") &&
+          isWantedClientPage(p.path)
+      )
+      .sort((a, b) => b.path.localeCompare(a.path));
+
+    const byBase = new Map<string, LLMPage[]>();
+    for (const p of clientPages) {
+      const base = getClientBase(p.path);
+      const list = byBase.get(base) ?? [];
+      if (list.length < 3) list.push(p);
+      byBase.set(base, list);
+    }
+
+    const selected = CLIENT_BASES.flatMap((base) => byBase.get(base) ?? []);
+    return selected
+      .map((p) => formatClientLink(p, state))
+      .filter((line): line is string => line !== null)
+      .join("\n");
+  };
+
+  // --- APIs: HTTP API intro, security, persistent subscriptions, optional headers, API reference ---
+  const apis: TemplateGetter = createSlugOrderSection(
+    latestServerPrefix + "http-api/",
+    ["introduction", "security", "persistent", "optional-http-headers", "api"],
+    (slug, p, _prefix, _prefixBase) => {
+      if (!p.path.includes(`http-api/${slug}`)) return false;
+      if (slug === "persistent" && p.path.includes("persistent-subscriptions"))
+        return false;
+      return true;
+    }
+  );
+
+  // --- Core Concepts: streams, projections, persistent subscriptions, connectors, admin-ui, indexes, archiving, queries (with index URL normalization) ---
+  const concepts: TemplateGetter = (pages, state) => {
+    const prefix = latestServerPrefix + "features/";
+    const featurePages = pages.filter((p) => p.path.startsWith(prefix));
+    const pickOne = (pred: (p: LLMPage) => boolean) => featurePages.find(pred);
+    const selected: LLMPage[] = [];
+    const add = (p: LLMPage | undefined) => {
+      if (p && !selected.some((x) => x.path === p.path)) selected.push(p);
+    };
+    const conceptPredicates: Array<(p: LLMPage) => boolean> = [
+      (p) => p.path.includes("streams"),
+      (p) =>
+        p.path.includes("projections") &&
+        (p.path.includes("projections/index") ||
+          p.path.includes("projections/introduction") ||
+          p.path.endsWith("projections/")),
+      (p) => p.path.includes("persistent-subscriptions"),
+      (p) =>
+        p.path.includes("connectors") &&
+        (p.path.endsWith("connectors/") || p.path.includes("connectors/index")),
+      (p) => p.path.includes("admin-ui"),
+      (p) => p.path.includes("indexes/default"),
+      (p) => p.path.includes("archiving"),
+      (p) => p.path.includes("queries/ui"),
+    ];
+    conceptPredicates.forEach((pred) => add(pickOne(pred)));
+    if (!selected.some((p) => p.path.includes("indexes")))
+      add(pickOne((p) => p.path.includes("indexes")));
+    if (!selected.some((p) => p.path.includes("queries")))
+      add(pickOne((p) => p.path.includes("queries")));
+    return selected
+      .map((p) => {
+        let url = generateLink(p.path, state);
+        if (isBrokenIndexUrl(url)) url = normalizeIndexUrl(url);
+        const title = (p as LLMPage & { title?: string }).title ?? "Documentation";
+        const desc = getPageDescription(p);
+        return desc
+          ? `- [${title}](${url}): ${desc.replace(/\n/g, ": ")}`
+          : `- [${title}](${url})`;
+      })
+      .join("\n");
+  };
+
+  // --- Configuration: overview, cluster, networking, db-config ---
+  const configuration: TemplateGetter = createSlugOrderSection(
+    latestServerPrefix + "configuration/",
+    ["configuration", "cluster", "networking", "db-config"],
+    (slug, p, prefix, prefixBase) =>
+      slug === "configuration"
+        ? matchIndexSlug(p, prefix, prefixBase, "configuration") ||
+          p.path.includes("/configuration/configuration")
+        : p.path.includes(slug)
+  );
+
+  // --- Diagnostics: overview, logs, metrics, integrations, best-practices ---
+  const diagnostics: TemplateGetter = createSlugOrderSection(
+    latestServerPrefix + "diagnostics/",
+    ["diagnostics", "logs", "metrics", "integrations", "best-practices"],
+    (slug, p, prefix, prefixBase) =>
+      slug === "diagnostics"
+        ? matchIndexSlug(p, prefix, prefixBase, "diagnostics") ||
+          p.path.includes("/diagnostics/diagnostics")
+        : p.path.includes(slug)
+  );
+
+  // --- Security & Access Control: all server security pages (exclude http-api); stable order by path ---
+  const security: TemplateGetter = createFilterSection(
+    (p) =>
+      p.path.startsWith(latestServerPrefix) &&
+      (p.path.includes("security") || p.path.includes("configuration/security")) &&
+      !p.path.includes("http-api"),
+    8,
+    { sortBy: (a, b) => a.path.localeCompare(b.path) }
+  );
+
+  // --- Release Notes: latest server only ---
+  const releaseNotes: TemplateGetter = createFilterSection(
+    (p) =>
+      p.path.startsWith(latestServerPrefix) &&
+      (p.path.includes("release-schedule") ||
+        p.path.includes("release-notes") ||
+        p.path.includes("whatsnew")),
+    10,
+    { sortBy: (a, b) => a.path.localeCompare(b.path) }
+  );
+
+  // --- Tutorials & Use Cases: dev-center tutorials and use-cases; stable order by path ---
+  const tutorials: TemplateGetter = createFilterSection(
+    (p) =>
+      p.path.startsWith("/dev-center/") &&
+      (p.path.includes("tutorials") || p.path.includes("use-cases")),
+    20,
+    { sortBy: (a, b) => a.path.localeCompare(b.path) }
+  );
+
+  // --- Kurrent Cloud: curated top pages; rest in llms-full.txt ---
+  const cloud: TemplateGetter = createSlugOrderSection(
+    "/cloud/",
+    [
+      "",
+      "introduction",
+      "getting-started",
+      "ops/backups",
+      "ops/sizing",
+      "ops/events",
+      "ops/account-security",
+      "networking",
+      "automation",
+      "faq"
+    ],
+    (slug, p, prefix, prefixBase) =>
+      slug === ""
+        ? p.path === prefix || p.path === prefixBase
+        : p.path.includes(slug)
+  );
+
+  // --- Kubernetes Operator: latest operator version docs (empty section if no operator version) ---
+  const kubernetesOperator: TemplateGetter = createPrefixSection(
+    latestOperatorPrefix,
+    { limit: 25 }
+  );
+
+  // --- Operations & Management: all server operations pages; stable order by path (includes index, backup, restore, auto-scavenge, etc.) ---
+  const operations: TemplateGetter = createFilterSection(
+    (p) =>
+      p.path.startsWith(latestServerPrefix) && p.path.includes("operations"),
+    15,
+    { sortBy: (a, b) => a.path.localeCompare(b.path) }
+  );
+
+  // --- Connectors Sinks: features/connectors/sinks under latest server ---
+  const connectorsSinks: TemplateGetter = createPrefixSection(
+    latestServerPrefix + "features/connectors/sinks/",
+    { limit: 25 }
+  );
+
+  // --- Community & Learning: static list of Kurrent site, forum, blog, Discord, GitHub, Academy ---
+  const community: TemplateGetter = () => {
+    return `- [Kurrent – Main website](https://www.kurrent.io): Event-native data platform for event sourcing and event-driven architecture.
+- [Kurrent Forum](https://discuss.kurrent.io): Community forum for KurrentDB and EventStoreDB questions and discussion.
+- [Kurrent Blog](https://www.kurrent.io/blog): Articles, guides, and release updates.
+- [Kurrent Webinars](https://www.kurrent.io/webinars): On-demand and upcoming webinars.
+- [Kurrent Community Discord](https://discord.gg/Phn9pmCw3t): Join the Kurrent community on Discord.
+- [Kurrent on YouTube](https://www.youtube.com/@Kurrent_io): Video tutorials, demos, and talks.
+- [Kurrent on GitHub](https://github.com/kurrent-io): KurrentDB server, client libraries, and open-source projects.
+- [Kurrent Academy](https://academy.kurrent.io): Free self-paced and live training on KurrentDB and event sourcing.`;
+  };
+
+  /**
+   * Markdown template for llms.txt. Placeholders {overview}, {concepts}, etc. are
+   * replaced by the corresponding getter's output. Section order is by importance
+   * for LLMs (overview → concepts → clients → APIs → config → … → community).
+   */
+  const CURATED_TEMPLATE = `# Kurrent Docs – Human-Readable Index for AI (llms.txt)
+
+Kurrent is the event-native data platform (database formerly known as EventStoreDB), built for event sourcing, CQRS, and event-driven architecture. This file points to the most important documentation sections for KurrentDB, ordered by importance for understanding and using KurrentDB. These links reflect authoritative, up-to-date docs from docs.kurrent.io.
+
+For exhaustive coverage (all documentation pages in one file), use \`llms-full.txt\` at the same base URL (e.g. \`${baseUrl}/llms-full.txt\`). LLMs and tooling that need the complete list of docs can fetch that file instead.
+
+---
+
+## Overview
+{overview}
+
+---
+
+## Core Concepts & Patterns
+{concepts}
+
+---
+
+## Client Libraries & Examples
+{clients}
+
+---
+
+## APIs
+{apis}
+
+---
+
+## Configuration
+{configuration}
+
+---
+
+## Installation & Deployment
+{installation}
+
+---
+
+## Security & Access Control
+{security}
+
+---
+
+## Operations & Management
+{operations}
+
+---
+
+## Diagnostics
+{diagnostics}
+
+---
+
+## Connectors Sinks
+{connectorsSinks}
+
+---
+
+## Kubernetes Operator
+{kubernetesOperator}
+
+---
+
+## Kurrent Cloud
+{cloud}
+
+---
+
+## Tutorials & Use Cases
+{tutorials}
+
+---
+
+## Release Notes / Changelog
+{releaseNotes}
+
+---
+
+## Community & Learning
+{community}
+`;
+
+  /** Map of template placeholder names to getter functions; keys must match placeholders in CURATED_TEMPLATE. */
+  const getters: TemplateGetterOptions = {
+    overview,
+    cloud,
+    installation,
+    kubernetesOperator,
+    configuration,
+    diagnostics,
+    clients,
+    apis,
+    concepts,
+    connectorsSinks,
+    operations,
+    security,
+    releaseNotes,
+    tutorials,
+    community,
+  };
+
+  /** Plugin options: domain for full URLs, llms.txt curated + full + per-page, template and getters. */
+  return {
+    domain: baseUrl,
+    llmsTxt: true,
+    llmsFullTxt: true,
+    llmsPageTxt: true,
+    llmsTxtTemplate: CURATED_TEMPLATE,
+    llmsTxtTemplateGetter: getters,
+  };
+}

--- a/docs/.vuepress/configs/llms.ts
+++ b/docs/.vuepress/configs/llms.ts
@@ -565,7 +565,7 @@ For exhaustive coverage (all documentation pages in one file), use \`llms-full.t
 
 ---
 
-## Configuration
+## Configuration (KurrentDB Server)
 {configuration}
 
 ---
@@ -590,12 +590,12 @@ For exhaustive coverage (all documentation pages in one file), use \`llms-full.t
 
 ---
 
-## Connectors Sinks
+## Connectors Sinks (KurrentDB Server)
 {connectorsSinks}
 
 ---
 
-## Kubernetes Operator
+## Kubernetes Operator (KurrentDB Server)
 {kubernetesOperator}
 
 ---
@@ -610,7 +610,7 @@ For exhaustive coverage (all documentation pages in one file), use \`llms-full.t
 
 ---
 
-## Release Notes / Changelog
+## Release Notes / Changelog (KurrentDB Server)
 {releaseNotes}
 
 ---


### PR DESCRIPTION
### **User description**
# Replace flat sitemap `llms.txt` with curated, AI-optimized index

## Summary

This PR replaces the auto-generated flat sitemap `llms.txt` with a curated, categorized index optimized for LLM consumption. Both versions are generated via `@vuepress/plugin-llms` — the difference is that we now supply **custom template getters** (`getLlmsPluginOptions()`) to filter, deduplicate, organize, and describe pages instead of dumping everything into a single flat list.

The exhaustive dump is preserved as `llms-full.txt` and cross-referenced from the new file's header. Per-page markdown (`llms-page.txt`) continues to generate as before.

---

## Why this matters

When an LLM (ChatGPT, Claude, Copilot, etc.) ingests `llms.txt` — whether via an agent fetch, RAG pipeline, or IDE integration — the file's quality directly determines whether the model can find the right content, for the right version, without wasting context window tokens.

The old file made this nearly impossible. The new file makes it straightforward.

---

## What changed

### Implementation

A new `getLlmsPluginOptions()` function provides custom template getters for 15 sections of the curated `llms.txt`. The code is organized around four reusable **factory helpers**:

| Factory | Used for | Selection strategy |
|---|---|---|
| `createSlugOrderSection` | Installation, APIs, Configuration, Diagnostics, Cloud | Picks exactly one page per slug in a fixed order |
| `createPrefixSection` | Kubernetes Operator, Connectors Sinks | Includes all pages under a path prefix, sorted alphabetically |
| `createFilterSection` | Operations, Security, Tutorials | Includes pages matching a predicate, with optional stable sorting, capped at a limit |
| `createFilterSlugOrderSection` | Release Notes | Filters by predicate, then picks one page per slug in fixed order |

Additional helpers:
- **`matchIndexSlug`** — reusable predicate for matching index/overview pages (e.g., `/quick-start/` or `/quick-start/index`)
- **`getPageDescription`** — extracts description from frontmatter or auto-excerpt
- **`normalizeIndexUrl`** — fixes broken `/.md` URLs to `/index.md`

Key design decisions:

- **Version resolution is dynamic** — `versioning.latest` determines the server prefix; the Kubernetes operator version is resolved from `versioning.versions`. No hardcoded version strings.
- **Stable ordering** — sections using `createFilterSection` can pass a `sortBy` comparator for deterministic output regardless of VuePress page order.
- **Curated Cloud section** — instead of including all ~22 Cloud pages, the getter selects the ~6 most important (introduction, backups, sizing, events, account security, FAQ).
- **HTTP API Security deduplication** — the security getter explicitly excludes `http-api` paths, so this page appears only under APIs.

The plugin is configured with all three output modes:

```typescript
{
  llmsTxt: true,       // curated index (this PR)
  llmsFullTxt: true,   // exhaustive dump at llms-full.txt
  llmsPageTxt: true,   // per-page markdown
}
```

### Output comparison at a glance

| Aspect | Old `llms.txt` | New `llms.txt` |
|---|---|---|
| **Generation method** | Default plugin (all pages) | Custom template getters with filtering |
| **Sections** | 1 (`## Table of Contents`) | 15 categorized sections |
| **Entry count** | ~500+ links | ~100 links |
| **Versions included** | All (v5 → v26.0, all client versions) | Latest only (dynamic via `versioning.latest`) |
| **Descriptions** | None (1 exception) | Auto-excerpt or frontmatter for most entries |
| **URL format** | Relative (`/server/v26.0/...`) | Absolute (`https://docs.kurrent.io/...`) |
| **Product context** | One-line tagline | Intro paragraph + `llms-full.txt` cross-reference |
| **Cloud docs** | All ~22 pages in flat list | Curated 6 most important pages |
| **Kubernetes Operator** | All 6 operator versions listed | Latest only (v1.5.0), dedicated section |
| **Connector sinks** | Only reachable via version-specific paths | Dedicated section listing all 8 sinks |
| **Output stability** | Depends on VuePress page order | Deterministic via slug ordering or `sortBy` |

### Section order

Sections are ordered by importance for LLM comprehension — understanding what the product is, then how to use it, then how to operate it:

```
Overview → Core Concepts → Client Libraries → APIs → Configuration →
Installation → Security → Operations → Diagnostics → Connectors Sinks →
Kubernetes Operator → Kurrent Cloud → Tutorials → Release Notes → Community
```

---

## Detailed comparison

### Before: flat dump, no version awareness

```markdown
# Kurrent Docs

> The stream database built for Event Sourcing

## Table of Contents

- [Appending events](/clients/dotnet/legacy/v23.3/appending-events.md)
- [Appending events](/clients/dotnet/v1.0/appending-events.md)
- [Appending events](/clients/dotnet/v1.1/appending-events.md)
- [Appending events](/clients/dotnet/v1.2/appending-events.md)
- [Appending events](/clients/dotnet/v1.3/appending-events.md)
...
- [Clustering](/server/v22.10/cluster.md)
- [Clustering](/server/v23.10/configuration/cluster.md)
- [Clustering](/server/v24.10/configuration/cluster.md)
- [Clustering](/server/v25.0/configuration/cluster.md)
- [Clustering](/server/v26.0/configuration/cluster.md)
...
- [FAQ](/cloud/faq.md)
- [AWS](/cloud/getting-started/private-access/aws.md)
- [Microsoft Azure](/cloud/getting-started/private-access/azure.md)
- [Google Cloud Platform](/cloud/getting-started/private-access/gcp.md)
- [Public Access Clusters](/cloud/getting-started/public.md)
- [Connect from Kubernetes](/cloud/guides/kubernetes.md)
- [Migrating data](/cloud/guides/migration.md)
... (22+ cloud pages)
...
(~500 total entries)
```

**Problems:**

- "Appending events" appears **18 times** — which is current?
- "Clustering" appears **7 times** across server versions
- All 22+ Cloud pages listed with no prioritization
- Kubernetes Operator "Installation" appears **6 times** — every operator version
- No descriptions, no grouping, relative URLs, no product context

### After: curated, categorized, described

```markdown
# Kurrent Docs – Human-Readable Index for AI (llms.txt)

Kurrent is the event-native data platform (database formerly known as
EventStoreDB), built for event sourcing, CQRS, and event-driven architecture.
...

For exhaustive coverage, use `llms-full.txt` at the same base URL.

---

## Configuration
- [Clustering](https://docs.kurrent.io/server/v26.0/configuration/cluster.md):
  KurrentDB allows you to run more than one node in a cluster for high availability...
- [Networking](https://docs.kurrent.io/server/v26.0/configuration/networking.md):
  KurrentDB provides two interfaces: HTTP(S) for gRPC communication and REST APIs...
- [Database settings](https://docs.kurrent.io/server/v26.0/configuration/db-config.md):
  Only modify these settings if you know what you are doing...

---

## Kurrent Cloud
- [Introduction](https://docs.kurrent.io/cloud/introduction.md): What is Kurrent Cloud?...
- [Backup and Restore](https://docs.kurrent.io/cloud/ops/backups.md): It is important to take regular backups...
- [Cloud instance sizing guide](https://docs.kurrent.io/cloud/ops/sizing.md): Use this guide to assess...
- [Events and notifications](https://docs.kurrent.io/cloud/ops/events.md): On the Event Console...
- [Account Security](https://docs.kurrent.io/cloud/ops/account-security.md): Multi-factor Authentication...
- [FAQ](https://docs.kurrent.io/cloud/faq.md): Cluster provisioning...
```

---

## How the generation works

```
llmsTxtTemplate (markdown string with {placeholders})
       │
       ├── {overview}           → custom getter    → getting-started/* pages
       ├── {concepts}           → custom getter    → features/* by slug, with index URL normalization
       ├── {clients}            → custom getter    → latest version per language, 3 pages each
       ├── {apis}               → slugOrderSection → http-api/* in fixed order
       ├── {configuration}      → slugOrderSection → configuration/* in fixed order
       ├── {installation}       → slugOrderSection → quick-start/* (excludes whatsnew)
       ├── {security}           → filterSection    → security/* (excludes http-api), sorted by path
       ├── {operations}         → filterSection    → operations/*, sorted by path
       ├── {diagnostics}        → slugOrderSection → diagnostics/* in fixed order
       ├── {connectorsSinks}    → prefixSection    → features/connectors/sinks/* (sorted)
       ├── {kubernetesOperator} → prefixSection    → kubernetes-operator/v1.5.0/*
       ├── {cloud}              → slugOrderSection → curated top ~6 Cloud pages
       ├── {tutorials}          → filterSection    → /dev-center/*, sorted by path
       ├── {releaseNotes}       → filterSlugOrder  → whatsnew, release-notes in fixed order
       └── {community}          → custom getter    → hardcoded external links
```

**Description priority:** frontmatter `description` → auto-excerpt → omitted. Descriptions improve automatically as authors add `description` to page frontmatter.

---

## Scenario walkthrough

### "How do I append events using the Python client?"

| | Old | New |
|---|---|---|
| **Matches** | 3 entries titled "Appending events" for Python v1.0, v1.1, v1.2 | 1 entry: `Python – Appending events` with description |
| **LLM can identify correct page?** | Must guess version | Yes, immediately |

### "How do I get started with Kurrent Cloud?"

| | Old | New |
|---|---|---|
| **Matches** | 22+ Cloud pages in flat list, no prioritization | 6 curated pages starting with Introduction |
| **LLM can identify starting point?** | Must scan all entries | Yes, Introduction is first |

### "How do I deploy KurrentDB on Kubernetes?"

| | Old | New |
|---|---|---|
| **Matches** | ~36 entries across 6 operator versions | 7 entries for latest operator (v1.5.0) |

---

## Limitations and known issues

### 1. Descriptions are auto-generated excerpts, not hand-written summaries

Most descriptions come from VuePress's auto-excerpt (~first 200 characters). This causes:

| Issue | Example | Impact |
|---|---|---|
| **Empty/echo descriptions** | `Auto-Scavenge: Auto-Scavenge`, `Redaction: Redaction` | LLM learns nothing |
| **Mid-word truncation** | `...using thi...` | Looks broken |
| **Title repetition** | `Backup and restore: Backup and restore Backing up...` | Wastes tokens |
| **Missing descriptions** | `Kafka Sink`, `Elasticsearch Sink` (no description) | LLM must fetch to understand |

**Mitigation**: The generator prioritizes frontmatter `description`. Adding it to any page immediately improves the output:

```yaml
---
description: Configure the Kafka Sink connector to stream events from KurrentDB to Apache Kafka topics.
---
```

### 2. Community section is hardcoded

Community links are static strings rather than VuePress-derived data. Fine for rarely-changing URLs, but requires a code change if any URL changes.

---

## Recommended follow-ups

| Improvement | Effort | Impact |
|---|---|---|
| Add frontmatter `description` to ~25 pages with empty/echo descriptions | Low | **High** |
| Add Connectors Sources section when more sources ship (currently only Kafka) | Low | Low |


___

### **PR Type**
Enhancement


___

### **Description**
- Replace flat sitemap with curated, AI-optimized llms.txt index

- Organize documentation into 15 categorized sections by importance

- Reduce entry count from 500+ to ~100 links with descriptions

- Use dynamic version resolution and custom template getters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VuePress Config"] -->|imports| B["getLlmsPluginOptions"]
  B -->|uses| C["Versioning Object"]
  C -->|resolves| D["Latest Server Path"]
  C -->|resolves| E["Latest Operator Path"]
  B -->|creates| F["15 Section Getters"]
  F -->|uses| G["Factory Helpers"]
  G -->|generates| H["Curated llms.txt"]
  H -->|includes| I["Overview, Concepts, APIs, Config, etc."]
  B -->|enables| J["llms-full.txt exhaustive dump"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Wire up custom LLMs plugin configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.vuepress/config.ts

<ul><li>Import new <code>getLlmsPluginOptions</code> function from llms config<br> <li> Pass versioning object to <code>llmsPlugin()</code> instead of empty config<br> <li> Enable custom template getters for curated llms.txt generation</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/954/files#diff-d6bc2c4b08fb339d0b296294e24adcaf16db0294915900c58b33ddce5033385b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llms.ts</strong><dd><code>Implement curated LLMs plugin configuration with section getters</code></dd></summary>
<hr>

docs/.vuepress/configs/llms.ts

<ul><li>Create 15 section getters (overview, concepts, clients, APIs, <br>configuration, etc.)<br> <li> Implement 4 factory helpers: <code>createPrefixSection</code>, <br><code>createSlugOrderSection</code>, <code>createFilterSection</code>, <br><code>createFilterSlugOrderSection</code><br> <li> Add URL normalization and description extraction utilities<br> <li> Define curated markdown template with dynamic version-based prefixes<br> <li> Support latest server and Kubernetes operator versions via versioning <br>object</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/documentation/pull/954/files#diff-1fa78cf2703110136ae41c930b36fac803e5e7947f47f348dcbb76a873916573">+649/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

