### PR TITLE
[ADV-286] Remove custom dark-mode overrides for Kapa widget portal

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -61,16 +61,6 @@ body:has(#kapa-widget-container) .vp-back-to-top-button {
   text-align: left;
 }
 
-html[data-theme="dark"] #kapa-widget-portal {
-  code {
-    background: rgba(127, 127, 127, 0.12);
-  }
-
-  blockquote {
-    border-color: #eee;
-  }
-}
-
 /* Fix for center-alignment issue on `.not-found` pages */
 .vp-page.not-found .theme-hope-content,
 .vp-page.not-found .vp-breadcrumb,


### PR DESCRIPTION
## Summary

Removes the `html[data-theme="dark"] #kapa-widget-portal` CSS block from `docs/.vuepress/styles/index.scss`. That block was overriding `code` and `blockquote` styles inside the Kapa chat portal in dark mode.

Kapa’s widget bundle now fully controls those styles, avoiding conflicts with upstream Kapa styling updates.

Resolves #961 