### PR TITLE
Add Tooling navbar dropdown linking to Gaffer

### DIFF
--- a/docs/.vuepress/configs/navbar.ts
+++ b/docs/.vuepress/configs/navbar.ts
@@ -32,6 +32,12 @@ export const navbarEn: NavbarOptions = [
         ],
     },
     {
+        text: "Tooling",
+        children: [
+            {text: "Gaffer (Projections tooling)", link: "https://gaffer.kurrent.io"},
+        ],
+    },
+    {
         text: "Developer Resources",
         children:
             [


### PR DESCRIPTION
Adds a new **Tooling** dropdown to the docs navbar, between **Clients & APIs** and **Developer Resources**, with a single entry linking out to the Gaffer mini-site:

```
… · Clients & APIs · Tooling ▾ · Developer Resources
                      └─ Gaffer (Projections tooling) → https://gaffer.kurrent.io
```

The external link gets the theme's external-icon + new-tab behaviour automatically, matching the other outbound nav entries. The dropdown is intentionally a container for more currently-undocumented tools to be added later.